### PR TITLE
Mark all views held onto by framework as unowned

### DIFF
--- a/DeclarativeLayout/Classes/SubviewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/SubviewLayoutComponent.swift
@@ -5,7 +5,7 @@ public class SubviewLayoutComponent<T: UIView, R: UIView>: ViewLayoutComponent<T
     /**
      The component's view's superview
      */
-    public let superview: R
+    public unowned let superview: R
     
     init(view: T,
          superview: R)

--- a/DeclarativeLayout/Classes/UIStackViewSubviewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/UIStackViewSubviewLayoutComponent.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: SubviewLayoutComponent<T, R>, UIStackViewLayoutComponentType {
     
-    var downcastedView: UIStackView { return view as UIStackView }
+    unowned var downcastedView: UIStackView { return view as UIStackView }
     private(set) var arrangedSubviews = [UIView]()
     private(set) var customSpacings = [(afterView: UIView, space: CGFloat)]()
     

--- a/DeclarativeLayout/Classes/UIViewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/UIViewLayoutComponent.swift
@@ -1,5 +1,5 @@
 import UIKit
 
 public class UIViewLayoutComponent<T: UIView>: ViewLayoutComponent<T>, UIViewLayoutComponentType {
-    var downcastedView: UIView { return view as UIView }
+    unowned var downcastedView: UIView { return view as UIView }
 }

--- a/DeclarativeLayout/Classes/UIViewSubviewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/UIViewSubviewLayoutComponent.swift
@@ -1,5 +1,5 @@
 import UIKit
 
 public class UIViewSubviewLayoutComponent<T: UIView, R: UIView>: SubviewLayoutComponent<T, R>, UIViewLayoutComponentType {
-    var downcastedView: UIView { return view as UIView }
+    unowned var downcastedView: UIView { return view as UIView }
 }

--- a/DeclarativeLayout/Classes/ViewLayout.swift
+++ b/DeclarativeLayout/Classes/ViewLayout.swift
@@ -1,6 +1,6 @@
 public class ViewLayout<T: UIView> {
     
-    private let view: T
+    private unowned var view: T
     private var currentLayoutComponent: UIViewLayoutComponent<T>
     
     /**

--- a/DeclarativeLayout/Classes/ViewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/ViewLayoutComponent.swift
@@ -27,7 +27,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
     /**
      The component's view. 
      */
-    public let view: T
+    public unowned let view: T
     private(set) var subviews = [UIView]()
     private(set) var sublayoutComponents = [LayoutComponentType]()
     private var constraints = [LayoutConstraint]()


### PR DESCRIPTION
Otherwise custom UIViews that had their own ViewLayout object would
create a circular reference. It doesn't make sense for this object to
exist when the view it holds onto doesn't, so it will crash in that
scenario. If people end up having trouble debugging why things are
crashing i'll switch to using preconditions as well to give better
error messages.