### PR TITLE
Simplify layout for use in other libraries

### DIFF
--- a/DeclarativeLayout/Classes/UIStackViewSubviewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/UIStackViewSubviewLayoutComponent.swift
@@ -14,7 +14,7 @@ public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: Subvi
         - layoutClosure: A closure that will define the layout component for the subview.
      */
     public func addArrangedView<Q>(_ subview: Q,
-                                   layoutClosure: ((UIViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)?)
+                                   layoutClosure: ((UIViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)? = nil)
     {
         arrangedSubviews.append(subview)
         
@@ -31,7 +31,7 @@ public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: Subvi
      This will allow you to, in the layout closure, add arranged views for the passed in stack view.
      */
     public func addArrangedStackView<Q>(_ subview: Q,
-                                        layoutClosure: ((UIStackViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)?)
+                                        layoutClosure: ((UIStackViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)? = nil)
     {
         arrangedSubviews.append(subview)
 

--- a/DeclarativeLayout/Classes/UIStackViewSubviewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/UIStackViewSubviewLayoutComponent.swift
@@ -12,13 +12,14 @@ public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: Subvi
      - parameters:
         - subview: The view you would like to add as a subview to the component's view.
         - layoutClosure: A closure that will define the layout component for the subview.
+     - returns: The layout component for the subview (the same one passed into the optional closure)
      */
-    public func addArrangedView<Q>(_ subview: Q,
-                                   layoutClosure: ((UIViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)? = nil)
+    @discardableResult public func addArrangedView<Q>(_ subview: Q,
+                                                      layoutClosure: ((UIViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)? = nil) -> UIViewSubviewLayoutComponent<Q, T>
     {
         arrangedSubviews.append(subview)
         
-        addView(subview, layoutClosure: layoutClosure)
+        return addView(subview, layoutClosure: layoutClosure)
     }
     
     /**
@@ -27,15 +28,16 @@ public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: Subvi
      - parameters:
         - subview: The view you would like to add as a subview to the component's view.
         - layoutClosure: A closure that will define the layout component for the subview.
+     - returns: The layout component for the subview (the same one passed into the optional closure)
      
      This will allow you to, in the layout closure, add arranged views for the passed in stack view.
      */
-    public func addArrangedStackView<Q>(_ subview: Q,
-                                        layoutClosure: ((UIStackViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)? = nil)
+    @discardableResult public func addArrangedStackView<Q>(_ subview: Q,
+                                                           layoutClosure: ((UIStackViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<Q, T>
     {
         arrangedSubviews.append(subview)
 
-        addStackView(subview, layoutClosure: layoutClosure)
+        return addStackView(subview, layoutClosure: layoutClosure)
     }
     
     /**

--- a/DeclarativeLayout/Classes/ViewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/ViewLayoutComponent.swift
@@ -44,7 +44,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
         - layoutClosure: A closure that will define the layout component for the subview.
      */
     public func addView<R>(_ subview: R,
-                           layoutClosure: ((UIViewSubviewLayoutComponent<R, T>, R, T) -> Void)?)
+                           layoutClosure: ((UIViewSubviewLayoutComponent<R, T>, R, T) -> Void)? = nil)
     {
         subview.translatesAutoresizingMaskIntoConstraints = false
         let subLayoutComponent = UIViewSubviewLayoutComponent(view: subview,
@@ -66,7 +66,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      This will allow you to, in the layout closure, add arranged views for the passed in stack view.
      */
     public func addStackView<R>(_ subview: R,
-                                layoutClosure: ((UIStackViewSubviewLayoutComponent<R, T>, R, T) -> Void)?)
+                                layoutClosure: ((UIStackViewSubviewLayoutComponent<R, T>, R, T) -> Void)? = nil)
     {
         subview.translatesAutoresizingMaskIntoConstraints = false
         let subLayoutComponent = UIStackViewSubviewLayoutComponent(view: subview,

--- a/DeclarativeLayout/Classes/ViewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/ViewLayoutComponent.swift
@@ -42,9 +42,10 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      - parameters:
         - subview: The view you would like to add as a subview to the component's view.
         - layoutClosure: A closure that will define the layout component for the subview.
+     - returns: The layout component for the subview (the same one passed into the optional closure)
      */
-    public func addView<R>(_ subview: R,
-                           layoutClosure: ((UIViewSubviewLayoutComponent<R, T>, R, T) -> Void)? = nil)
+    @discardableResult public func addView<R>(_ subview: R,
+                                              layoutClosure: ((UIViewSubviewLayoutComponent<R, T>, R, T) -> Void)? = nil) -> UIViewSubviewLayoutComponent<R, T>
     {
         subview.translatesAutoresizingMaskIntoConstraints = false
         let subLayoutComponent = UIViewSubviewLayoutComponent(view: subview,
@@ -54,6 +55,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
         subviews.append(subview)
         
         layoutClosure?(subLayoutComponent, subview, view)
+        return subLayoutComponent
     }
     
     /**
@@ -62,11 +64,12 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      - parameters:
         - subview: The view you would like to add as a subview to the component's view.
         - layoutClosure: A closure that will define the layout component for the subview.
+     - returns: The layout component for the subview (the same one passed into the optional closure)
      
      This will allow you to, in the layout closure, add arranged views for the passed in stack view.
      */
-    public func addStackView<R>(_ subview: R,
-                                layoutClosure: ((UIStackViewSubviewLayoutComponent<R, T>, R, T) -> Void)? = nil)
+    @discardableResult public func addStackView<R>(_ subview: R,
+                                                   layoutClosure: ((UIStackViewSubviewLayoutComponent<R, T>, R, T) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<R, T>
     {
         subview.translatesAutoresizingMaskIntoConstraints = false
         let subLayoutComponent = UIStackViewSubviewLayoutComponent(view: subview,
@@ -76,6 +79,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
         subviews.append(subview)
         
         layoutClosure?(subLayoutComponent, subview, view)
+        return subLayoutComponent
     }
     
     /**


### PR DESCRIPTION
There may be other libraries that provide more opinionated layout systems, or provide higher level APIs. These libraries could perhaps leverage DeclarativeLayout to give them the declarative functionality. 

This will allow these types of libraries (and users) to use DeclarativeLayout without being required to use its closure-based API, since that is mostly there for aesthetic reasons when you are directly using DeclarativeLayout