### PR TITLE
Fix bug when removing arranged subview and adding as arranged subview to a different stackview

### DIFF
--- a/DeclarativeLayout/Classes/ViewLayout.swift
+++ b/DeclarativeLayout/Classes/ViewLayout.swift
@@ -83,6 +83,10 @@ public class ViewLayout<T: UIView> {
         for (view, currentLayoutComponent) in currentArrangedSubviews {
             if newArrangedSubviews[view] == nil {
                 view.removeFromSuperview()
+            } else if let newComponent = newArrangedSubviews[view],
+                newComponent.downcastedView != currentLayoutComponent.downcastedView
+            {
+                view.removeFromSuperview()
             }
         }
     }


### PR DESCRIPTION
If you removed an arranged subview from one stackview and added it as an arranged subview to another stackview, it wouldn't remove the view from the first stackview.