### PR TITLE
Remove view and superview

### DIFF
--- a/DeclarativeLayout/Classes/UIStackViewSubviewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/UIStackViewSubviewLayoutComponent.swift
@@ -16,7 +16,7 @@ public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: Subvi
      If you are calling `updateLayoutTo` more than once, you should not use this as it will cause
      unnecessary layout recalculations to occur.
      */
-    @discardableResult public func addArrangedView<UIView>(layoutClosure: ((UIViewSubviewLayoutComponent<UIView, T>, UIView, T) -> Void)? = nil) -> UIViewSubviewLayoutComponent<UIView, T>
+    @discardableResult public func addArrangedView<UIView>(layoutClosure: ((UIViewSubviewLayoutComponent<UIView, T>) -> Void)? = nil) -> UIViewSubviewLayoutComponent<UIView, T>
     {
         return addArrangedView(UIView(), layoutClosure: layoutClosure)
     }
@@ -30,7 +30,7 @@ public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: Subvi
      - returns: The layout component for the subview (the same one passed into the optional closure)
      */
     @discardableResult public func addArrangedView<Q>(_ subview: Q,
-                                                      layoutClosure: ((UIViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)? = nil) -> UIViewSubviewLayoutComponent<Q, T>
+                                                      layoutClosure: ((UIViewSubviewLayoutComponent<Q, T>) -> Void)? = nil) -> UIViewSubviewLayoutComponent<Q, T>
     {
         arrangedSubviews.append(subview)
         
@@ -49,7 +49,7 @@ public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: Subvi
      * If you are calling `updateLayoutTo` more than once, you should not use this as it will cause
      unnecessary layout recalculations to occur.
      */
-    @discardableResult public func addArrangedStackView<UIStackView>(layoutClosure: ((UIStackViewSubviewLayoutComponent<UIStackView, T>, UIStackView, T) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<UIStackView, T>
+    @discardableResult public func addArrangedStackView<UIStackView>(layoutClosure: ((UIStackViewSubviewLayoutComponent<UIStackView, T>) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<UIStackView, T>
     {
         return addArrangedStackView(UIStackView(), layoutClosure: layoutClosure)
     }
@@ -65,7 +65,7 @@ public class UIStackViewSubviewLayoutComponent<T: UIStackView, R: UIView>: Subvi
      This will allow you to, in the layout closure, add arranged views for the passed in stack view.
      */
     @discardableResult public func addArrangedStackView<Q>(_ subview: Q,
-                                                           layoutClosure: ((UIStackViewSubviewLayoutComponent<Q, T>, Q, T) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<Q, T>
+                                                           layoutClosure: ((UIStackViewSubviewLayoutComponent<Q, T>) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<Q, T>
     {
         arrangedSubviews.append(subview)
 

--- a/DeclarativeLayout/Classes/ViewLayout.swift
+++ b/DeclarativeLayout/Classes/ViewLayout.swift
@@ -20,9 +20,9 @@ public class ViewLayout<T: UIView> {
      - parameters:
         - layoutClosure: A closure that will define the layout component for the ViewLayout's view
      */
-    public func updateLayoutTo(_ layoutClosure: (UIViewLayoutComponent<T>, T) -> ()) {
+    public func updateLayoutTo(_ layoutClosure: (UIViewLayoutComponent<T>) -> ()) {
         let layoutComponent = UIViewLayoutComponent(view: view)
-        layoutClosure(layoutComponent, view)
+        layoutClosure(layoutComponent)
         
         removeUnneededArrangedSubviews(with: layoutComponent)
         removeUnneededLayougGuides(with: layoutComponent)

--- a/DeclarativeLayout/Classes/ViewLayoutComponent.swift
+++ b/DeclarativeLayout/Classes/ViewLayoutComponent.swift
@@ -55,7 +55,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      If you are calling `updateLayoutTo` more than once, you should not use this as it will cause
      unnecessary layout recalculations to occur.
      */
-    @discardableResult public func addView(layoutClosure: ((UIViewSubviewLayoutComponent<UIView, T>, UIView, T) -> Void)? = nil) -> UIViewSubviewLayoutComponent<UIView, T>
+    @discardableResult public func addView(layoutClosure: ((UIViewSubviewLayoutComponent<UIView, T>) -> Void)? = nil) -> UIViewSubviewLayoutComponent<UIView, T>
     {
         return addView(UIView(), layoutClosure: layoutClosure)
     }
@@ -69,7 +69,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      - returns: The layout component for the subview (the same one passed into the optional closure)
      */
     @discardableResult public func addView<R>(_ subview: R,
-                                              layoutClosure: ((UIViewSubviewLayoutComponent<R, T>, R, T) -> Void)? = nil) -> UIViewSubviewLayoutComponent<R, T>
+                                              layoutClosure: ((UIViewSubviewLayoutComponent<R, T>) -> Void)? = nil) -> UIViewSubviewLayoutComponent<R, T>
     {
         subview.translatesAutoresizingMaskIntoConstraints = false
         let subLayoutComponent = UIViewSubviewLayoutComponent(view: subview,
@@ -78,7 +78,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
         sublayoutComponents.append(.uiview(layout: subLayoutComponent))
         subviews.append(subview)
         
-        layoutClosure?(subLayoutComponent, subview, view)
+        layoutClosure?(subLayoutComponent)
         return subLayoutComponent
     }
     
@@ -94,7 +94,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      If you are calling `updateLayoutTo` more than once, you should not use this as it will cause
      unnecessary layout recalculations to occur.
      */
-    @discardableResult public func addStackView(layoutClosure: ((UIStackViewSubviewLayoutComponent<UIStackView, T>, UIStackView, T) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<UIStackView, T>
+    @discardableResult public func addStackView(layoutClosure: ((UIStackViewSubviewLayoutComponent<UIStackView, T>) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<UIStackView, T>
     {
         return addStackView(UIStackView(), layoutClosure: layoutClosure)
     }
@@ -110,7 +110,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      This will allow you to, in the layout closure, add arranged views for the passed in stack view.
      */
     @discardableResult public func addStackView<R>(_ subview: R,
-                                                   layoutClosure: ((UIStackViewSubviewLayoutComponent<R, T>, R, T) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<R, T>
+                                                   layoutClosure: ((UIStackViewSubviewLayoutComponent<R, T>) -> Void)? = nil) -> UIStackViewSubviewLayoutComponent<R, T>
     {
         subview.translatesAutoresizingMaskIntoConstraints = false
         let subLayoutComponent = UIStackViewSubviewLayoutComponent(view: subview,
@@ -119,7 +119,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
         sublayoutComponents.append(.uistackview(layout: subLayoutComponent))
         subviews.append(subview)
         
-        layoutClosure?(subLayoutComponent, subview, view)
+        layoutClosure?(subLayoutComponent)
         return subLayoutComponent
     }
     
@@ -133,7 +133,7 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      If you are calling `updateLayoutTo` more than once, you should not use this as it will cause
      unnecessary layout recalculations to occur.
      */
-    @discardableResult public func addLayoutGuide(layoutClosure: ((UILayoutGuideComponent<T>, UILayoutGuide, T) -> Void)? = nil) -> UILayoutGuideComponent<T> {
+    @discardableResult public func addLayoutGuide(layoutClosure: ((UILayoutGuideComponent<T>) -> Void)? = nil) -> UILayoutGuideComponent<T> {
         return addLayoutGuide(UILayoutGuide(), layoutClosure: layoutClosure)
     }
     
@@ -146,13 +146,13 @@ public class ViewLayoutComponent<T: UIView>: ViewLayoutComponentType {
      - returns: The layout component for the layout guide (the same one passed into the optional closure)
      */
     @discardableResult public func addLayoutGuide(_ layoutGuide: UILayoutGuide,
-                                                  layoutClosure: ((UILayoutGuideComponent<T>, UILayoutGuide, T) -> Void)? = nil) -> UILayoutGuideComponent<T> {
+                                                  layoutClosure: ((UILayoutGuideComponent<T>) -> Void)? = nil) -> UILayoutGuideComponent<T> {
         let subLayoutComponent = UILayoutGuideComponent(layoutGuide: layoutGuide,
                                                         owningView: view)
         sublayoutComponents.append(.layoutGuide(layout: subLayoutComponent))
         layoutGuides.append(layoutGuide)
         
-        layoutClosure?(subLayoutComponent, layoutGuide, view)
+        layoutClosure?(subLayoutComponent)
         return subLayoutComponent
     }
     

--- a/Example/DeclarativeLayout/MenuViewController.swift
+++ b/Example/DeclarativeLayout/MenuViewController.swift
@@ -34,13 +34,13 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     private func layoutAllViews() {
-        viewLayout.updateLayoutTo { (component, view) in
-            component.addView(tableView) { (component, view, superview) in
+        viewLayout.updateLayoutTo { (component) in
+            component.addView(tableView) { (component) in
                 component.activate([
-                    view.topAnchor.constraint(equalTo: superview.topAnchor),
-                    view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                    view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
-                    view.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
+                    component.view.topAnchor.constraint(equalTo: component.superview.topAnchor),
+                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
+                    component.view.bottomAnchor.constraint(equalTo: component.superview.bottomAnchor),
                 ])
             }
         }

--- a/Example/DeclarativeLayout/MenuViewController.swift
+++ b/Example/DeclarativeLayout/MenuViewController.swift
@@ -1,6 +1,32 @@
 import UIKit
 import DeclarativeLayout
 
+// MARK: - Layout extensions
+
+private extension UIViewLayoutComponent {
+    func layout(closure: (T) -> [NSLayoutConstraint]) {
+        activate(closure(view))
+    }
+}
+
+private extension UIViewSubviewLayoutComponent {
+    func layout(closure: (T, R) -> [NSLayoutConstraint]) {
+        activate(closure(view, superview))
+    }
+}
+
+private extension UIStackViewSubviewLayoutComponent {
+    func layout(closure: (T, R) -> [NSLayoutConstraint]) {
+        activate(closure(view, superview))
+    }
+}
+
+private extension UILayoutGuideComponent {
+    func layout(closure: (R) -> [NSLayoutConstraint]) {
+        activate(closure(owningView))
+    }
+}
+
 class MenuViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
     enum Row {
@@ -36,12 +62,12 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     private func layoutAllViews() {
         viewLayout.updateLayoutTo { (component) in
             component.addView(tableView) { (component) in
-                component.activate([
-                    component.view.topAnchor.constraint(equalTo: component.superview.topAnchor),
-                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
-                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
-                    component.view.bottomAnchor.constraint(equalTo: component.superview.bottomAnchor),
-                ])
+                component.layout {[
+                    $0.topAnchor.constraint(equalTo: $1.topAnchor),
+                    $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor),
+                    $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor),
+                    $0.bottomAnchor.constraint(equalTo: $1.bottomAnchor),
+                ]}
             }
         }
     }

--- a/Example/DeclarativeLayout/QuickStartViewController.swift
+++ b/Example/DeclarativeLayout/QuickStartViewController.swift
@@ -42,61 +42,61 @@ class QuickStartViewController: UIViewController {
     
     private func layoutAllViews(withLayoutType layoutType: LayoutType) {
         
-        viewLayout.updateLayoutTo { (component, view) in
-            component.addView(self.headerLabel) { (component, view, superview) in
+        viewLayout.updateLayoutTo { (component) in
+            component.addView(self.headerLabel) { (component) in
                 // view is the headerLabel, superview is the VC's view
                 component.activate([
-                    view.topAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.topAnchor, constant: 35),
-                    view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-                    view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
+                    component.view.topAnchor.constraint(equalTo: component.superview.safeAreaLayoutGuide.topAnchor, constant: 35),
+                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
                 ])
             }
             
-            component.addStackView(self.stackView) { (component, view, superview) in
-                view.axis = .vertical
+            component.addStackView(self.stackView) { (component) in
+                component.view.axis = .vertical
                 component.activate([
-                    view.topAnchor.constraint(equalTo: self.headerLabel.bottomAnchor, constant: 20),
-                    view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-                    view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
+                    component.view.topAnchor.constraint(equalTo: self.headerLabel.bottomAnchor, constant: 20),
+                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
                 ])
                 
-                component.addArrangedView(self.redBox) { (component, view, superview) in
+                component.addArrangedView(self.redBox) { (component) in
                     component.activate([
-                        view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                        view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+                        component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                        component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
                     ])
                     
                     if layoutType == .layout1 { // In layout1 the blue box will be inside of the red box
-                        component.addView(self.blueBox) { (component, view, superview) in
+                        component.addView(self.blueBox) { (component) in
                             component.activate([
-                                view.topAnchor.constraint(equalTo: superview.topAnchor, constant: 20),
-                                view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-                                view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
-                                view.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -20),
-                                view.heightAnchor.constraint(equalToConstant: 100)
+                                component.view.topAnchor.constraint(equalTo: component.superview.topAnchor, constant: 20),
+                                component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+                                component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
+                                component.view.bottomAnchor.constraint(equalTo: component.superview.bottomAnchor, constant: -20),
+                                component.view.heightAnchor.constraint(equalToConstant: 100)
                             ])
                         }
                     } else {
                         component.activate([
-                            view.heightAnchor.constraint(equalToConstant: 200)
+                            component.view.heightAnchor.constraint(equalToConstant: 200)
                         ])
                     }
                 }
                 
                 if layoutType == .layout1 { // layout1 has a green box, layout 2 does not
-                    component.addArrangedView(self.greenBox) { (component, view, superview) in
+                    component.addArrangedView(self.greenBox) { (component) in
                         component.activate([
-                            view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                            view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
-                            view.heightAnchor.constraint(equalToConstant: 300),
+                            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
+                            component.view.heightAnchor.constraint(equalToConstant: 300),
                         ])
                     }
                 }
                 
                 if layoutType == .layout2 { // In layout2 the blue box will be below the red box
-                    component.addArrangedView(self.blueBox) { (component, view, superview) in
+                    component.addArrangedView(self.blueBox) { (component) in
                         component.activate([
-                            view.heightAnchor.constraint(equalToConstant: 100)
+                            component.view.heightAnchor.constraint(equalToConstant: 100)
                         ])
                     }
                 }

--- a/Example/DeclarativeLayout/RegistrationExampleWithFrameworkViewController.swift
+++ b/Example/DeclarativeLayout/RegistrationExampleWithFrameworkViewController.swift
@@ -27,59 +27,59 @@ class RegistrationExampleWithFrameworkViewController: UIViewController {
     
     private func layoutAllViews() {
         
-        viewLayout.updateLayoutTo { (component, view) in
-            component.addStackView(self.stackView) { (component, view, superview) in
-                view.axis = .vertical
+        viewLayout.updateLayoutTo { (component) in
+            component.addStackView(self.stackView) { (component) in
+                component.view.axis = .vertical
                 component.activate([
-                    view.topAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.topAnchor, constant: 35),
-                    view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-                    view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
+                    component.view.topAnchor.constraint(equalTo: component.superview.safeAreaLayoutGuide.topAnchor, constant: 35),
+                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
                 ])
                 
                 component.addArrangedView(self.registerOrSignInSegmentedControl)
                 component.addSpace(30)
                 component.addArrangedView(self.headerLabel)
                 component.addSpace(20)
-                component.addArrangedView(self.emailContainerView) { (component, view, superview) in
-                    component.addView(self.emailLabel) { (component, view, superview) in
+                component.addArrangedView(self.emailContainerView) { (component) in
+                    component.addView(self.emailLabel) { (component) in
                         component.activate([
-                            view.topAnchor.constraint(greaterThanOrEqualTo: superview.topAnchor),
-                            view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                            view.trailingAnchor.constraint(equalTo: self.emailTextField.leadingAnchor, constant: -20),
-                            view.bottomAnchor.constraint(lessThanOrEqualTo: superview.bottomAnchor),
-                            view.centerYAnchor.constraint(equalTo: superview.centerYAnchor),
+                            component.view.topAnchor.constraint(greaterThanOrEqualTo: component.superview.topAnchor),
+                            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                            component.view.trailingAnchor.constraint(equalTo: self.emailTextField.leadingAnchor, constant: -20),
+                            component.view.bottomAnchor.constraint(lessThanOrEqualTo: component.superview.bottomAnchor),
+                            component.view.centerYAnchor.constraint(equalTo: component.superview.centerYAnchor),
                         ])
                     }
                     
-                    component.addView(self.emailTextField) { (component, view, superview) in
+                    component.addView(self.emailTextField) { (component) in
                         component.activate([
-                            view.topAnchor.constraint(greaterThanOrEqualTo: superview.topAnchor),
-                            view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
-                            view.bottomAnchor.constraint(lessThanOrEqualTo: superview.bottomAnchor),
-                            view.centerYAnchor.constraint(equalTo: superview.centerYAnchor),
+                            component.view.topAnchor.constraint(greaterThanOrEqualTo: component.superview.topAnchor),
+                            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
+                            component.view.bottomAnchor.constraint(lessThanOrEqualTo: component.superview.bottomAnchor),
+                            component.view.centerYAnchor.constraint(equalTo: component.superview.centerYAnchor),
                         ])
                     }
                 }
                 
                 component.addSpace(40)
-                component.addArrangedView(self.passwordContainerView) { (component, view, superview) in
-                    component.addView(self.passwordLabel) { (component, view, superview) in
+                component.addArrangedView(self.passwordContainerView) { (component) in
+                    component.addView(self.passwordLabel) { (component) in
                         component.activate([
-                            view.topAnchor.constraint(greaterThanOrEqualTo: superview.topAnchor),
-                            view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                            view.trailingAnchor.constraint(equalTo: self.passwordTextField.leadingAnchor, constant: -20),
-                            view.bottomAnchor.constraint(lessThanOrEqualTo: superview.bottomAnchor),
-                            view.centerYAnchor.constraint(equalTo: superview.centerYAnchor),
+                            component.view.topAnchor.constraint(greaterThanOrEqualTo: component.superview.topAnchor),
+                            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                            component.view.trailingAnchor.constraint(equalTo: self.passwordTextField.leadingAnchor, constant: -20),
+                            component.view.bottomAnchor.constraint(lessThanOrEqualTo: component.superview.bottomAnchor),
+                            component.view.centerYAnchor.constraint(equalTo: component.superview.centerYAnchor),
                         ])
                     }
                     
-                    component.addView(self.passwordTextField) { (component, view, superview) in
+                    component.addView(self.passwordTextField) { (component) in
                         component.activate([
-                            view.topAnchor.constraint(greaterThanOrEqualTo: superview.topAnchor),
-                            view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
-                            view.bottomAnchor.constraint(lessThanOrEqualTo: superview.bottomAnchor),
-                            view.centerYAnchor.constraint(equalTo: superview.centerYAnchor),
-                            view.leadingAnchor.constraint(equalTo: self.emailTextField.leadingAnchor),
+                            component.view.topAnchor.constraint(greaterThanOrEqualTo: component.superview.topAnchor),
+                            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
+                            component.view.bottomAnchor.constraint(lessThanOrEqualTo: component.superview.bottomAnchor),
+                            component.view.centerYAnchor.constraint(equalTo: component.superview.centerYAnchor),
+                            component.view.leadingAnchor.constraint(equalTo: self.emailTextField.leadingAnchor),
                         ])
                     }
                 }
@@ -88,10 +88,10 @@ class RegistrationExampleWithFrameworkViewController: UIViewController {
                 component.addArrangedView(self.submitButton)
             }
             
-            component.addView(self.forgotMyPasswordButton) { (component, view, superview) in
+            component.addView(self.forgotMyPasswordButton) { (component) in
                 component.activate([
-                    view.topAnchor.constraint(equalTo: self.stackView.bottomAnchor, constant: 20),
-                    view.centerXAnchor.constraint(equalTo: superview.centerXAnchor),
+                    component.view.topAnchor.constraint(equalTo: self.stackView.bottomAnchor, constant: 20),
+                    component.view.centerXAnchor.constraint(equalTo: component.superview.centerXAnchor),
                 ])
             }
         }

--- a/Example/DeclarativeLayout/RegistrationExampleWithFrameworkViewController.swift
+++ b/Example/DeclarativeLayout/RegistrationExampleWithFrameworkViewController.swift
@@ -1,6 +1,32 @@
 import UIKit
 import DeclarativeLayout
 
+// MARK: - Layout extensions
+
+private extension UIViewLayoutComponent {
+    func layout(closure: (T) -> [NSLayoutConstraint]) {
+        activate(closure(view))
+    }
+}
+
+private extension UIViewSubviewLayoutComponent {
+    func layout(closure: (T, R) -> [NSLayoutConstraint]) {
+        activate(closure(view, superview))
+    }
+}
+
+private extension UIStackViewSubviewLayoutComponent {
+    func layout(closure: (T, R) -> [NSLayoutConstraint]) {
+        activate(closure(view, superview))
+    }
+}
+
+private extension UILayoutGuideComponent {
+    func layout(closure: (R) -> [NSLayoutConstraint]) {
+        activate(closure(owningView))
+    }
+}
+
 class RegistrationExampleWithFrameworkViewController: UIViewController {
     
     private lazy var viewLayout = ViewLayout(view: view)
@@ -30,11 +56,11 @@ class RegistrationExampleWithFrameworkViewController: UIViewController {
         viewLayout.updateLayoutTo { (component) in
             component.addStackView(self.stackView) { (component) in
                 component.view.axis = .vertical
-                component.activate([
-                    component.view.topAnchor.constraint(equalTo: component.superview.safeAreaLayoutGuide.topAnchor, constant: 35),
-                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
-                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
-                ])
+                component.layout {[ // $0 is component's view, $1 is its superview
+                    $0.topAnchor.constraint(equalTo: $1.safeAreaLayoutGuide.topAnchor, constant: 35),
+                    $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor, constant: 20),
+                    $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor, constant: -20),
+                ]}
                 
                 component.addArrangedView(self.registerOrSignInSegmentedControl)
                 component.addSpace(30)
@@ -42,45 +68,45 @@ class RegistrationExampleWithFrameworkViewController: UIViewController {
                 component.addSpace(20)
                 component.addArrangedView(self.emailContainerView) { (component) in
                     component.addView(self.emailLabel) { (component) in
-                        component.activate([
-                            component.view.topAnchor.constraint(greaterThanOrEqualTo: component.superview.topAnchor),
-                            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
-                            component.view.trailingAnchor.constraint(equalTo: self.emailTextField.leadingAnchor, constant: -20),
-                            component.view.bottomAnchor.constraint(lessThanOrEqualTo: component.superview.bottomAnchor),
-                            component.view.centerYAnchor.constraint(equalTo: component.superview.centerYAnchor),
-                        ])
+                        component.layout {[
+                            $0.topAnchor.constraint(greaterThanOrEqualTo: $1.topAnchor),
+                            $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor),
+                            $0.trailingAnchor.constraint(equalTo: self.emailTextField.leadingAnchor, constant: -20),
+                            $0.bottomAnchor.constraint(lessThanOrEqualTo: $1.bottomAnchor),
+                            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor),
+                        ]}
                     }
                     
                     component.addView(self.emailTextField) { (component) in
-                        component.activate([
-                            component.view.topAnchor.constraint(greaterThanOrEqualTo: component.superview.topAnchor),
-                            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
-                            component.view.bottomAnchor.constraint(lessThanOrEqualTo: component.superview.bottomAnchor),
-                            component.view.centerYAnchor.constraint(equalTo: component.superview.centerYAnchor),
-                        ])
+                        component.layout {[
+                            $0.topAnchor.constraint(greaterThanOrEqualTo: $1.topAnchor),
+                            $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor),
+                            $0.bottomAnchor.constraint(lessThanOrEqualTo: $1.bottomAnchor),
+                            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor),
+                        ]}
                     }
                 }
                 
                 component.addSpace(40)
                 component.addArrangedView(self.passwordContainerView) { (component) in
                     component.addView(self.passwordLabel) { (component) in
-                        component.activate([
-                            component.view.topAnchor.constraint(greaterThanOrEqualTo: component.superview.topAnchor),
-                            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
-                            component.view.trailingAnchor.constraint(equalTo: self.passwordTextField.leadingAnchor, constant: -20),
-                            component.view.bottomAnchor.constraint(lessThanOrEqualTo: component.superview.bottomAnchor),
-                            component.view.centerYAnchor.constraint(equalTo: component.superview.centerYAnchor),
-                        ])
+                        component.layout {[
+                            $0.topAnchor.constraint(greaterThanOrEqualTo: $1.topAnchor),
+                            $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor),
+                            $0.trailingAnchor.constraint(equalTo: self.passwordTextField.leadingAnchor, constant: -20),
+                            $0.bottomAnchor.constraint(lessThanOrEqualTo: $1.bottomAnchor),
+                            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor),
+                        ]}
                     }
                     
                     component.addView(self.passwordTextField) { (component) in
-                        component.activate([
-                            component.view.topAnchor.constraint(greaterThanOrEqualTo: component.superview.topAnchor),
-                            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
-                            component.view.bottomAnchor.constraint(lessThanOrEqualTo: component.superview.bottomAnchor),
-                            component.view.centerYAnchor.constraint(equalTo: component.superview.centerYAnchor),
-                            component.view.leadingAnchor.constraint(equalTo: self.emailTextField.leadingAnchor),
-                        ])
+                        component.layout {[
+                            $0.topAnchor.constraint(greaterThanOrEqualTo: $1.topAnchor),
+                            $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor),
+                            $0.bottomAnchor.constraint(lessThanOrEqualTo: $1.bottomAnchor),
+                            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor),
+                            $0.leadingAnchor.constraint(equalTo: self.emailTextField.leadingAnchor),
+                        ]}
                     }
                 }
                 
@@ -89,10 +115,10 @@ class RegistrationExampleWithFrameworkViewController: UIViewController {
             }
             
             component.addView(self.forgotMyPasswordButton) { (component) in
-                component.activate([
-                    component.view.topAnchor.constraint(equalTo: self.stackView.bottomAnchor, constant: 20),
-                    component.view.centerXAnchor.constraint(equalTo: component.superview.centerXAnchor),
-                ])
+                component.layout {[
+                    $0.topAnchor.constraint(equalTo: self.stackView.bottomAnchor, constant: 20),
+                    $0.centerXAnchor.constraint(equalTo: $1.centerXAnchor),
+                ]}
             }
         }
     }

--- a/Example/DeclarativeLayout/WithFrameworkAndAnchorage/RegistrationExampleWithFrameworkAndAnchorageViewController.swift
+++ b/Example/DeclarativeLayout/WithFrameworkAndAnchorage/RegistrationExampleWithFrameworkAndAnchorageViewController.swift
@@ -4,15 +4,39 @@ import Anchorage
 
 // MARK: - Layout extensions for Anchorage
 
-private extension ViewLayoutComponent {
-    func layout(closure: () -> Void) {
-        activate(Anchorage.batch(active: false, closure: closure))
+private extension UIViewLayoutComponent {
+    func layout(closure: @escaping (T) -> Void) {
+        let wrappingClosure: () -> Void = {
+            closure(self.view)
+        }
+        activate(Anchorage.batch(active: false, closure: wrappingClosure))
+    }
+}
+
+private extension UIViewSubviewLayoutComponent {
+    func layout(closure: @escaping (T, R) -> Void) {
+        let wrappingClosure: () -> Void = {
+            closure(self.view, self.superview)
+        }
+        activate(Anchorage.batch(active: false, closure: wrappingClosure))
+    }
+}
+
+private extension UIStackViewSubviewLayoutComponent {
+    func layout(closure: @escaping (T, R) -> Void) {
+        let wrappingClosure: () -> Void = {
+            closure(self.view, self.superview)
+        }
+        activate(Anchorage.batch(active: false, closure: wrappingClosure))
     }
 }
 
 private extension UILayoutGuideComponent {
-    func layout(closure: () -> Void) {
-        activate(Anchorage.batch(active: false, closure: closure))
+    func layout(closure: @escaping (R) -> Void) {
+        let wrappingClosure: () -> Void = {
+            closure(self.owningView)
+        }
+        activate(Anchorage.batch(active: false, closure: wrappingClosure))
     }
 }
 
@@ -47,10 +71,10 @@ class RegistrationExampleWithFrameworkAndAnchorageViewController: UIViewControll
         viewLayout.updateLayoutTo { (component) in
             component.addStackView(self.stackView) { (component) in
                 component.view.axis = .vertical
-                component.layout {
-                    component.view.topAnchor == component.superview.safeAreaLayoutGuide.topAnchor + 35
-                    component.view.leadingAnchor == component.superview.leadingAnchor + 20
-                    component.view.trailingAnchor == component.superview.trailingAnchor - 20
+                component.layout { // $0 is component's view, $1 is superview
+                    $0.topAnchor == $1.safeAreaLayoutGuide.topAnchor + 35
+                    $0.leadingAnchor == $1.leadingAnchor + 20
+                    $0.trailingAnchor == $1.trailingAnchor - 20
                 }
                 
                 component.addArrangedView(self.registerOrSignInSegmentedControl)
@@ -60,20 +84,20 @@ class RegistrationExampleWithFrameworkAndAnchorageViewController: UIViewControll
                 component.addArrangedView(self.emailContainerView) { (component) in
                     component.addView(self.emailLabel) { (component) in
                         component.layout {
-                            component.view.topAnchor >= component.superview.topAnchor
-                            component.view.leadingAnchor == component.superview.leadingAnchor
-                            component.view.trailingAnchor == self.emailTextField.leadingAnchor - 20
-                            component.view.bottomAnchor <= component.superview.bottomAnchor
-                            component.view.centerYAnchor == component.superview.centerYAnchor
+                            $0.topAnchor >= $1.topAnchor
+                            $0.leadingAnchor == $1.leadingAnchor
+                            $0.trailingAnchor == self.emailTextField.leadingAnchor - 20
+                            $0.bottomAnchor <= $1.bottomAnchor
+                            $0.centerYAnchor == $1.centerYAnchor
                         }
                     }
                     
                     component.addView(self.emailTextField) { (component) in
                         component.layout {
-                            component.view.topAnchor >= component.superview.topAnchor
-                            component.view.trailingAnchor == component.superview.trailingAnchor
-                            component.view.bottomAnchor <= component.superview.bottomAnchor
-                            component.view.centerYAnchor == component.superview.centerYAnchor
+                            $0.topAnchor >= $1.topAnchor
+                            $0.trailingAnchor == $1.trailingAnchor
+                            $0.bottomAnchor <= $1.bottomAnchor
+                            $0.centerYAnchor == $1.centerYAnchor
                         }
                     }
                 }
@@ -82,21 +106,21 @@ class RegistrationExampleWithFrameworkAndAnchorageViewController: UIViewControll
                 component.addArrangedView(self.passwordContainerView) { (component) in
                     component.addView(self.passwordLabel) { (component) in
                         component.layout {
-                            component.view.topAnchor >= component.superview.topAnchor
-                            component.view.leadingAnchor == component.superview.leadingAnchor
-                            component.view.trailingAnchor == self.passwordTextField.leadingAnchor - 20
-                            component.view.bottomAnchor <= component.superview.bottomAnchor
-                            component.view.centerYAnchor == component.superview.centerYAnchor
+                            $0.topAnchor >= $1.topAnchor
+                            $0.leadingAnchor == $1.leadingAnchor
+                            $0.trailingAnchor == self.passwordTextField.leadingAnchor - 20
+                            $0.bottomAnchor <= $1.bottomAnchor
+                            $0.centerYAnchor == $1.centerYAnchor
                         }
                     }
                     
                     component.addView(self.passwordTextField) { (component) in
                         component.layout {
-                            component.view.topAnchor >= component.superview.topAnchor
-                            component.view.trailingAnchor == component.superview.trailingAnchor
-                            component.view.bottomAnchor <= component.superview.bottomAnchor
-                            component.view.centerYAnchor == component.superview.centerYAnchor
-                            component.view.leadingAnchor == self.emailTextField.leadingAnchor
+                            $0.topAnchor >= $1.topAnchor
+                            $0.trailingAnchor == $1.trailingAnchor
+                            $0.bottomAnchor <= $1.bottomAnchor
+                            $0.centerYAnchor == $1.centerYAnchor
+                            $0.leadingAnchor == self.emailTextField.leadingAnchor
                         }
                     }
                 }
@@ -107,8 +131,8 @@ class RegistrationExampleWithFrameworkAndAnchorageViewController: UIViewControll
             
             component.addView(self.forgotMyPasswordButton) { (component) in
                 component.layout {
-                    component.view.topAnchor == self.stackView.bottomAnchor + 20
-                    component.view.centerXAnchor == component.superview.centerXAnchor
+                    $0.topAnchor == self.stackView.bottomAnchor + 20
+                    $0.centerXAnchor == $1.centerXAnchor
                 }
             }
         }

--- a/Example/DeclarativeLayout/WithFrameworkAndAnchorage/RegistrationExampleWithFrameworkAndAnchorageViewController.swift
+++ b/Example/DeclarativeLayout/WithFrameworkAndAnchorage/RegistrationExampleWithFrameworkAndAnchorageViewController.swift
@@ -44,59 +44,59 @@ class RegistrationExampleWithFrameworkAndAnchorageViewController: UIViewControll
     
     private func layoutAllViews() {
         
-        viewLayout.updateLayoutTo { (component, view) in
-            component.addStackView(self.stackView) { (component, view, superview) in
-                view.axis = .vertical
+        viewLayout.updateLayoutTo { (component) in
+            component.addStackView(self.stackView) { (component) in
+                component.view.axis = .vertical
                 component.layout {
-                    view.topAnchor == superview.safeAreaLayoutGuide.topAnchor + 35
-                    view.leadingAnchor == superview.leadingAnchor + 20
-                    view.trailingAnchor == superview.trailingAnchor - 20
+                    component.view.topAnchor == component.superview.safeAreaLayoutGuide.topAnchor + 35
+                    component.view.leadingAnchor == component.superview.leadingAnchor + 20
+                    component.view.trailingAnchor == component.superview.trailingAnchor - 20
                 }
                 
                 component.addArrangedView(self.registerOrSignInSegmentedControl)
                 component.addSpace(30)
                 component.addArrangedView(self.headerLabel)
                 component.addSpace(20)
-                component.addArrangedView(self.emailContainerView) { (component, view, superview) in
-                    component.addView(self.emailLabel) { (component, view, superview) in
+                component.addArrangedView(self.emailContainerView) { (component) in
+                    component.addView(self.emailLabel) { (component) in
                         component.layout {
-                            view.topAnchor >= superview.topAnchor
-                            view.leadingAnchor == superview.leadingAnchor
-                            view.trailingAnchor == self.emailTextField.leadingAnchor - 20
-                            view.bottomAnchor <= superview.bottomAnchor
-                            view.centerYAnchor == superview.centerYAnchor
+                            component.view.topAnchor >= component.superview.topAnchor
+                            component.view.leadingAnchor == component.superview.leadingAnchor
+                            component.view.trailingAnchor == self.emailTextField.leadingAnchor - 20
+                            component.view.bottomAnchor <= component.superview.bottomAnchor
+                            component.view.centerYAnchor == component.superview.centerYAnchor
                         }
                     }
                     
-                    component.addView(self.emailTextField) { (component, view, superview) in
+                    component.addView(self.emailTextField) { (component) in
                         component.layout {
-                            view.topAnchor >= superview.topAnchor
-                            view.trailingAnchor == superview.trailingAnchor
-                            view.bottomAnchor <= superview.bottomAnchor
-                            view.centerYAnchor == superview.centerYAnchor
+                            component.view.topAnchor >= component.superview.topAnchor
+                            component.view.trailingAnchor == component.superview.trailingAnchor
+                            component.view.bottomAnchor <= component.superview.bottomAnchor
+                            component.view.centerYAnchor == component.superview.centerYAnchor
                         }
                     }
                 }
                 
                 component.addSpace(40)
-                component.addArrangedView(self.passwordContainerView) { (component, view, superview) in
-                    component.addView(self.passwordLabel) { (component, view, superview) in
+                component.addArrangedView(self.passwordContainerView) { (component) in
+                    component.addView(self.passwordLabel) { (component) in
                         component.layout {
-                            view.topAnchor >= superview.topAnchor
-                            view.leadingAnchor == superview.leadingAnchor
-                            view.trailingAnchor == self.passwordTextField.leadingAnchor - 20
-                            view.bottomAnchor <= superview.bottomAnchor
-                            view.centerYAnchor == superview.centerYAnchor
+                            component.view.topAnchor >= component.superview.topAnchor
+                            component.view.leadingAnchor == component.superview.leadingAnchor
+                            component.view.trailingAnchor == self.passwordTextField.leadingAnchor - 20
+                            component.view.bottomAnchor <= component.superview.bottomAnchor
+                            component.view.centerYAnchor == component.superview.centerYAnchor
                         }
                     }
                     
-                    component.addView(self.passwordTextField) { (component, view, superview) in
+                    component.addView(self.passwordTextField) { (component) in
                         component.layout {
-                            view.topAnchor >= superview.topAnchor
-                            view.trailingAnchor == superview.trailingAnchor
-                            view.bottomAnchor <= superview.bottomAnchor
-                            view.centerYAnchor == superview.centerYAnchor
-                            view.leadingAnchor == self.emailTextField.leadingAnchor
+                            component.view.topAnchor >= component.superview.topAnchor
+                            component.view.trailingAnchor == component.superview.trailingAnchor
+                            component.view.bottomAnchor <= component.superview.bottomAnchor
+                            component.view.centerYAnchor == component.superview.centerYAnchor
+                            component.view.leadingAnchor == self.emailTextField.leadingAnchor
                         }
                     }
                 }
@@ -105,10 +105,10 @@ class RegistrationExampleWithFrameworkAndAnchorageViewController: UIViewControll
                 component.addArrangedView(self.submitButton)
             }
             
-            component.addView(self.forgotMyPasswordButton) { (component, view, superview) in
+            component.addView(self.forgotMyPasswordButton) { (component) in
                 component.layout {
-                    view.topAnchor == self.stackView.bottomAnchor + 20
-                    view.centerXAnchor == superview.centerXAnchor
+                    component.view.topAnchor == self.stackView.bottomAnchor + 20
+                    component.view.centerXAnchor == component.superview.centerXAnchor
                 }
             }
         }

--- a/Example/DeclarativeLayout/WithFrameworkAndSnapKit/RegistrationExampleWithFrameworkAndSnapKitViewController.swift
+++ b/Example/DeclarativeLayout/WithFrameworkAndSnapKit/RegistrationExampleWithFrameworkAndSnapKitViewController.swift
@@ -12,15 +12,36 @@ import SnapKit
 
 // MARK: - Layout extensions for Snapkit
 
-private extension ViewLayoutComponent {
-    func layout(closure: (ConstraintMaker) -> Void) {
+private extension UIViewLayoutComponent {
+    func layout(closure: @escaping (ConstraintMaker) -> Void) {
         activate(view.snp.prepareConstraints(closure).flatMap { $0.layoutConstraints })
     }
 }
 
+private extension UIViewSubviewLayoutComponent {
+    func layout(closure: @escaping (ConstraintMaker, R) -> Void) {
+        let wrappingClosure: (ConstraintMaker) -> Void = {
+            closure($0, self.superview)
+        }
+        activate(view.snp.prepareConstraints(wrappingClosure).flatMap { $0.layoutConstraints })
+    }
+}
+
+private extension UIStackViewSubviewLayoutComponent {
+    func layout(closure: @escaping (ConstraintMaker, R) -> Void) {
+        let wrappingClosure: (ConstraintMaker) -> Void = {
+            closure($0, self.superview)
+        }
+        activate(view.snp.prepareConstraints(wrappingClosure).flatMap { $0.layoutConstraints })
+    }
+}
+
 private extension UILayoutGuideComponent {
-    func layout(closure: (ConstraintMaker) -> Void) {
-        activate(layoutGuide.snp.prepareConstraints(closure).flatMap { $0.layoutConstraints })
+    func layout(closure: @escaping (ConstraintMaker, R) -> Void) {
+        let wrappingClosure: (ConstraintMaker) -> Void = {
+            closure($0, self.owningView)
+        }
+        activate(layoutGuide.snp.prepareConstraints(wrappingClosure).flatMap { $0.layoutConstraints })
     }
 }
 
@@ -55,10 +76,10 @@ class RegistrationExampleWithFrameworkAndSnapKitViewController: UIViewController
         viewLayout.updateLayoutTo { (component) in
             component.addStackView(self.stackView) { (component) in
                 component.view.axis = .vertical
-                component.layout { (make) -> Void in
-                    make.top.equalTo(component.superview.safeAreaLayoutGuide).offset(35)
-                    make.leading.equalTo(component.superview).offset(20)
-                    make.trailing.equalTo(component.superview).offset(-20)
+                component.layout { // $0 is ConstraintMaker, $1 is superview
+                    $0.top.equalTo($1.safeAreaLayoutGuide).offset(35)
+                    $0.leading.equalTo($1).offset(20)
+                    $0.trailing.equalTo($1).offset(-20)
                 }
                 
                 component.addArrangedView(self.registerOrSignInSegmentedControl)
@@ -67,21 +88,21 @@ class RegistrationExampleWithFrameworkAndSnapKitViewController: UIViewController
                 component.addSpace(20)
                 component.addArrangedView(self.emailContainerView) { (component) in
                     component.addView(self.emailLabel) { (component) in
-                        component.layout { (make) in
-                            make.top.greaterThanOrEqualTo(component.superview)
-                            make.leading.equalTo(component.superview)
-                            make.trailing.equalTo(self.emailTextField.snp.leading).offset(-20)
-                            make.bottom.lessThanOrEqualTo(component.superview)
-                            make.centerY.equalTo(component.superview)
+                        component.layout {
+                            $0.top.greaterThanOrEqualTo($1)
+                            $0.leading.equalTo($1)
+                            $0.trailing.equalTo(self.emailTextField.snp.leading).offset(-20)
+                            $0.bottom.lessThanOrEqualTo($1)
+                            $0.centerY.equalTo($1)
                         }
                     }
                     
                     component.addView(self.emailTextField) { (component) in
-                        component.layout { (make) in
-                            make.top.greaterThanOrEqualTo(component.superview)
-                            make.trailing.equalTo(component.superview)
-                            make.bottom.lessThanOrEqualTo(component.superview)
-                            make.centerY.equalTo(component.superview)
+                        component.layout {
+                            $0.top.greaterThanOrEqualTo($1)
+                            $0.trailing.equalTo($1)
+                            $0.bottom.lessThanOrEqualTo($1)
+                            $0.centerY.equalTo($1)
                         }
                     }
                 }
@@ -89,22 +110,22 @@ class RegistrationExampleWithFrameworkAndSnapKitViewController: UIViewController
                 component.addSpace(40)
                 component.addArrangedView(self.passwordContainerView) { (component) in
                     component.addView(self.passwordLabel) { (component) in
-                        component.layout { (make) in
-                            make.top.greaterThanOrEqualTo(component.superview)
-                            make.leading.equalTo(component.superview)
-                            make.trailing.equalTo(self.passwordTextField.snp.leading).offset(-20)
-                            make.bottom.lessThanOrEqualTo(component.superview)
-                            make.centerY.equalTo(component.superview)
+                        component.layout {
+                            $0.top.greaterThanOrEqualTo($1)
+                            $0.leading.equalTo($1)
+                            $0.trailing.equalTo(self.passwordTextField.snp.leading).offset(-20)
+                            $0.bottom.lessThanOrEqualTo($1)
+                            $0.centerY.equalTo($1)
                         }
                     }
                     
                     component.addView(self.passwordTextField) { (component) in
-                        component.layout { (make) in
-                            make.top.greaterThanOrEqualTo(component.superview)
-                            make.trailing.equalTo(component.superview)
-                            make.bottom.lessThanOrEqualTo(component.superview)
-                            make.centerY.equalTo(component.superview)
-                            make.leading.equalTo(self.emailTextField)
+                        component.layout {
+                            $0.top.greaterThanOrEqualTo($1)
+                            $0.trailing.equalTo($1)
+                            $0.bottom.lessThanOrEqualTo($1)
+                            $0.centerY.equalTo($1)
+                            $0.leading.equalTo(self.emailTextField)
                         }
                     }
                 }
@@ -114,9 +135,9 @@ class RegistrationExampleWithFrameworkAndSnapKitViewController: UIViewController
             }
             
             component.addView(self.forgotMyPasswordButton) { (component) in
-                component.layout { (make) in
-                    make.top.equalTo(self.stackView.snp.bottom).offset(20)
-                    make.centerX.equalTo(component.superview)
+                component.layout {
+                    $0.top.equalTo(self.stackView.snp.bottom).offset(20)
+                    $0.centerX.equalTo($1)
                 }
             }
         }

--- a/Example/DeclarativeLayout/WithFrameworkAndSnapKit/RegistrationExampleWithFrameworkAndSnapKitViewController.swift
+++ b/Example/DeclarativeLayout/WithFrameworkAndSnapKit/RegistrationExampleWithFrameworkAndSnapKitViewController.swift
@@ -52,58 +52,58 @@ class RegistrationExampleWithFrameworkAndSnapKitViewController: UIViewController
     
     private func layoutAllViews() {
         
-        viewLayout.updateLayoutTo { (component, view) in
-            component.addStackView(self.stackView) { (component, view, superview) in
-                view.axis = .vertical
+        viewLayout.updateLayoutTo { (component) in
+            component.addStackView(self.stackView) { (component) in
+                component.view.axis = .vertical
                 component.layout { (make) -> Void in
-                    make.top.equalTo(superview.safeAreaLayoutGuide).offset(35)
-                    make.leading.equalTo(superview).offset(20)
-                    make.trailing.equalTo(superview).offset(-20)
+                    make.top.equalTo(component.superview.safeAreaLayoutGuide).offset(35)
+                    make.leading.equalTo(component.superview).offset(20)
+                    make.trailing.equalTo(component.superview).offset(-20)
                 }
                 
                 component.addArrangedView(self.registerOrSignInSegmentedControl)
                 component.addSpace(30)
                 component.addArrangedView(self.headerLabel)
                 component.addSpace(20)
-                component.addArrangedView(self.emailContainerView) { (component, view, superview) in
-                    component.addView(self.emailLabel) { (component, view, superview) in
+                component.addArrangedView(self.emailContainerView) { (component) in
+                    component.addView(self.emailLabel) { (component) in
                         component.layout { (make) in
-                            make.top.greaterThanOrEqualTo(superview)
-                            make.leading.equalTo(superview)
+                            make.top.greaterThanOrEqualTo(component.superview)
+                            make.leading.equalTo(component.superview)
                             make.trailing.equalTo(self.emailTextField.snp.leading).offset(-20)
-                            make.bottom.lessThanOrEqualTo(superview)
-                            make.centerY.equalTo(superview)
+                            make.bottom.lessThanOrEqualTo(component.superview)
+                            make.centerY.equalTo(component.superview)
                         }
                     }
                     
-                    component.addView(self.emailTextField) { (component, view, superview) in
+                    component.addView(self.emailTextField) { (component) in
                         component.layout { (make) in
-                            make.top.greaterThanOrEqualTo(superview)
-                            make.trailing.equalTo(superview)
-                            make.bottom.lessThanOrEqualTo(superview)
-                            make.centerY.equalTo(superview)
+                            make.top.greaterThanOrEqualTo(component.superview)
+                            make.trailing.equalTo(component.superview)
+                            make.bottom.lessThanOrEqualTo(component.superview)
+                            make.centerY.equalTo(component.superview)
                         }
                     }
                 }
                 
                 component.addSpace(40)
-                component.addArrangedView(self.passwordContainerView) { (component, view, superview) in
-                    component.addView(self.passwordLabel) { (component, view, superview) in
+                component.addArrangedView(self.passwordContainerView) { (component) in
+                    component.addView(self.passwordLabel) { (component) in
                         component.layout { (make) in
-                            make.top.greaterThanOrEqualTo(superview)
-                            make.leading.equalTo(superview)
+                            make.top.greaterThanOrEqualTo(component.superview)
+                            make.leading.equalTo(component.superview)
                             make.trailing.equalTo(self.passwordTextField.snp.leading).offset(-20)
-                            make.bottom.lessThanOrEqualTo(superview)
-                            make.centerY.equalTo(superview)
+                            make.bottom.lessThanOrEqualTo(component.superview)
+                            make.centerY.equalTo(component.superview)
                         }
                     }
                     
-                    component.addView(self.passwordTextField) { (component, view, superview) in
+                    component.addView(self.passwordTextField) { (component) in
                         component.layout { (make) in
-                            make.top.greaterThanOrEqualTo(superview)
-                            make.trailing.equalTo(superview)
-                            make.bottom.lessThanOrEqualTo(superview)
-                            make.centerY.equalTo(superview)
+                            make.top.greaterThanOrEqualTo(component.superview)
+                            make.trailing.equalTo(component.superview)
+                            make.bottom.lessThanOrEqualTo(component.superview)
+                            make.centerY.equalTo(component.superview)
                             make.leading.equalTo(self.emailTextField)
                         }
                     }
@@ -113,10 +113,10 @@ class RegistrationExampleWithFrameworkAndSnapKitViewController: UIViewController
                 component.addArrangedView(self.submitButton)
             }
             
-            component.addView(self.forgotMyPasswordButton) { (component, view, superview) in
+            component.addView(self.forgotMyPasswordButton) { (component) in
                 component.layout { (make) in
                     make.top.equalTo(self.stackView.snp.bottom).offset(20)
-                    make.centerX.equalTo(superview)
+                    make.centerX.equalTo(component.superview)
                 }
             }
         }

--- a/Example/Tests/ExampleView.swift
+++ b/Example/Tests/ExampleView.swift
@@ -38,40 +38,40 @@ class ExampleView: UIView {
     
     private func layout(with viewLayout: ViewLayout<ExampleView>, views: [UIView], constant: CGFloat) {
         
-        viewLayout.updateLayoutTo { (component, view) in
+        viewLayout.updateLayoutTo { (component) in
             
-            component.addView(views[0]) { (component, view, superview) in
+            component.addView(views[0]) { (component) in
                 
                 component.activate([
-                    view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: constant),
-                    view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: constant),
-                    view.topAnchor.constraint(equalTo: superview.topAnchor, constant: constant),
-                    view.heightAnchor.constraint(equalToConstant: 10),
+                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: constant),
+                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: constant),
+                    component.view.topAnchor.constraint(equalTo: component.superview.topAnchor, constant: constant),
+                    component.view.heightAnchor.constraint(equalToConstant: 10),
                     ])
             }
             
             let viewsSlice = views.dropFirst().dropLast()
             for viewTuple in viewsSlice.enumerated() {
                 
-                component.addView(viewTuple.element) { (component, view, superview) in
+                component.addView(viewTuple.element) { (component) in
                     
                     component.activate([
-                        view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: constant),
-                        view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: constant),
-                        view.topAnchor.constraint(equalTo: views[viewTuple.offset].bottomAnchor, constant: constant),
-                        view.heightAnchor.constraint(equalToConstant: 10),
+                        component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: constant),
+                        component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: constant),
+                        component.view.topAnchor.constraint(equalTo: views[viewTuple.offset].bottomAnchor, constant: constant),
+                        component.view.heightAnchor.constraint(equalToConstant: 10),
                         ])
                 }
             }
             
-            component.addView(views.last!) { (component, view, superview) in
+            component.addView(views.last!) { (component) in
                 
                 component.activate([
-                    view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: constant),
-                    view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: constant),
-                    view.topAnchor.constraint(equalTo: views[views.count - 2].bottomAnchor, constant: constant),
-                    view.heightAnchor.constraint(equalToConstant: 10),
-                    view.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: constant),
+                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: constant),
+                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: constant),
+                    component.view.topAnchor.constraint(equalTo: views[views.count - 2].bottomAnchor, constant: constant),
+                    component.view.heightAnchor.constraint(equalToConstant: 10),
+                    component.view.bottomAnchor.constraint(equalTo: component.superview.bottomAnchor, constant: constant),
                     ])
             }
         }
@@ -79,37 +79,37 @@ class ExampleView: UIView {
     
     private func layoutNewConstraints(with viewLayout: ViewLayout<ExampleView>, views: [UIView], constant: CGFloat) {
         
-        viewLayout.updateLayoutTo { (component, view) in
+        viewLayout.updateLayoutTo { (component) in
             
-            component.addView(views[0]) { (component, view, superview) in
+            component.addView(views[0]) { (component) in
                 
                 component.activate([
-                    view.centerXAnchor.constraint(equalTo: superview.centerXAnchor),
-                    view.topAnchor.constraint(equalTo: superview.topAnchor, constant: constant),
-                    view.heightAnchor.constraint(equalToConstant: 10),
+                    component.view.centerXAnchor.constraint(equalTo: component.superview.centerXAnchor),
+                    component.view.topAnchor.constraint(equalTo: component.superview.topAnchor, constant: constant),
+                    component.view.heightAnchor.constraint(equalToConstant: 10),
                     ])
             }
             
             let viewsSlice = views.dropFirst().dropLast()
             for viewTuple in viewsSlice.enumerated() {
                 
-                component.addView(viewTuple.element) { (component, view, superview) in
+                component.addView(viewTuple.element) { (component) in
                     
                     component.activate([
-                        view.centerXAnchor.constraint(equalTo: superview.centerXAnchor),
-                        view.topAnchor.constraint(equalTo: views[viewTuple.offset].bottomAnchor, constant: constant),
-                        view.heightAnchor.constraint(equalToConstant: 10),
+                        component.view.centerXAnchor.constraint(equalTo: component.superview.centerXAnchor),
+                        component.view.topAnchor.constraint(equalTo: views[viewTuple.offset].bottomAnchor, constant: constant),
+                        component.view.heightAnchor.constraint(equalToConstant: 10),
                         ])
                 }
             }
             
-            component.addView(views.last!) { (component, view, superview) in
+            component.addView(views.last!) { (component) in
                 
                 component.activate([
-                    view.centerXAnchor.constraint(equalTo: superview.centerXAnchor),
-                    view.topAnchor.constraint(equalTo: views[views.count - 2].bottomAnchor, constant: constant),
-                    view.heightAnchor.constraint(equalToConstant: 10),
-                    view.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: constant),
+                    component.view.centerXAnchor.constraint(equalTo: component.superview.centerXAnchor),
+                    component.view.topAnchor.constraint(equalTo: views[views.count - 2].bottomAnchor, constant: constant),
+                    component.view.heightAnchor.constraint(equalToConstant: 10),
+                    component.view.bottomAnchor.constraint(equalTo: component.superview.bottomAnchor, constant: constant),
                     ])
             }
         }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ viewLayout = ViewLayout(view: view)
 Tell your `ViewLayout` you would like to update it
 
 ```swift
-viewLayout.updateLayoutTo { (component, view) in
+viewLayout.updateLayoutTo { (component) in
     ...
 }
 ```
@@ -49,47 +49,47 @@ Use the layout components to define new views that should be in the hierarchy, a
 Here is an example:
 
 ```swift
-viewLayout.updateLayoutTo { (component, view) in
-    component.addView(self.headerLabel) { (component, view, superview) in
+viewLayout.updateLayoutTo { (component) in
+    component.addView(self.headerLabel) { (component) in
 
-        // view is the headerLabel
-        // superview is the VC's view
+        // component.view is the headerLabel
+        // component.superview is the VC's view
         component.activate([
-            view.topAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.topAnchor, constant: 10),
-            view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-            view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
+            component.view.topAnchor.constraint(equalTo: component.superview.safeAreaLayoutGuide.topAnchor, constant: 10),
+            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
         ])
     }
 
-    component.addStackView(self.stackView) { (component, view, superview) in
+    component.addStackView(self.stackView) { (component) in
         component.activate([
-            view.topAnchor.constraint(equalTo: self.headerLabel.bottomAnchor, constant: 20),
-            view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-            view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
+            component.view.topAnchor.constraint(equalTo: self.headerLabel.bottomAnchor, constant: 20),
+            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
         ])
 
-        component.addArrangedView(self.redBox) { (component, view, superview) in
+        component.addArrangedView(self.redBox) { (component) in
             component.activate([
-                view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+                component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
             ])
 
-            component.addView(self.blueBox) { (component, view, superview) in
+            component.addView(self.blueBox) { (component) in
                 component.activate([
-                    view.topAnchor.constraint(equalTo: superview.topAnchor, constant: 20),
-                    view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-                    view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
-                    view.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -20),
-                    view.heightAnchor.constraint(equalToConstant: 100)
+                    component.view.topAnchor.constraint(equalTo: component.superview.topAnchor, constant: 20),
+                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
+                    component.view.bottomAnchor.constraint(equalTo: component.superview.bottomAnchor, constant: -20),
+                    component.view.heightAnchor.constraint(equalToConstant: 100)
                 ])
             }
         }
 
-        component.addArrangedView(self.greenBox) { (component, view, superview) in
+        component.addArrangedView(self.greenBox) { (component) in
             component.activate([
-                view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
-                view.heightAnchor.constraint(equalToConstant: 300),
+                component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
+                component.view.heightAnchor.constraint(equalToConstant: 300),
             ])
         }
     }
@@ -109,62 +109,62 @@ That will give you a view looking like this:
 Imagine that `self.layoutType` was changed inbetween calls to update the layout.
 
 ```swift
-viewLayout.updateLayoutTo { (component, view) in
-    component.addView(self.headerLabel) { (component, view, superview) in
+viewLayout.updateLayoutTo { (component) in
+    component.addView(self.headerLabel) { (component) in
 
-        // view is the headerLabel
-        // superview is the VC's view
+        // component.view is the headerLabel
+        // component.superview is the VC's view
         component.activate([
-            view.topAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.topAnchor, constant: 10),
-            view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-            view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
+            component.view.topAnchor.constraint(equalTo: component.superview.safeAreaLayoutGuide.topAnchor, constant: 10),
+            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
         ])
     }
 
-    component.addStackView(self.stackView) { (component, view, superview) in
+    component.addStackView(self.stackView) { (component) in
         component.activate([
-            view.topAnchor.constraint(equalTo: self.headerLabel.bottomAnchor, constant: 20),
-            view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-            view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
+            component.view.topAnchor.constraint(equalTo: self.headerLabel.bottomAnchor, constant: 20),
+            component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+            component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
         ])
 
-        component.addArrangedView(self.redBox) { (component, view, superview) in
+        component.addArrangedView(self.redBox) { (component) in
             component.activate([
-                view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+                component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
             ])
 
             if self.layoutType == .layout1 { // In layout1 the blue box will be inside of the red box
-                component.addView(self.blueBox) { (component, view, superview) in
+                component.addView(self.blueBox) { (component) in
                     component.activate([
-                        view.topAnchor.constraint(equalTo: superview.topAnchor, constant: 20),
-                        view.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 20),
-                        view.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -20),
-                        view.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -20),
-                        view.heightAnchor.constraint(equalToConstant: 100)
+                        component.view.topAnchor.constraint(equalTo: component.superview.topAnchor, constant: 20),
+                        component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor, constant: 20),
+                        component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor, constant: -20),
+                        component.view.bottomAnchor.constraint(equalTo: component.superview.bottomAnchor, constant: -20),
+                        component.view.heightAnchor.constraint(equalToConstant: 100)
                     ])
                 }
             } else {
                 component.activate([
-                    view.heightAnchor.constraint(equalToConstant: 200)
+                    component.view.heightAnchor.constraint(equalToConstant: 200)
                 ])
             }
         }
 
         if self.layoutType == .layout1 { // layout1 has a green box, layout 2 does not
-            component.addArrangedView(self.greenBox) { (component, view, superview) in
+            component.addArrangedView(self.greenBox) { (component) in
                 component.activate([
-                    view.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                    view.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
-                    view.heightAnchor.constraint(equalToConstant: 300),
+                    component.view.leadingAnchor.constraint(equalTo: component.superview.leadingAnchor),
+                    component.view.trailingAnchor.constraint(equalTo: component.superview.trailingAnchor),
+                    component.view.heightAnchor.constraint(equalToConstant: 300),
                 ])
             }
         }
 
         if self.layoutType == .layout2 { // In layout2 the blue box will be below the red box
-            component.addArrangedView(self.blueBox) { (component, view, superview) in
+            component.addArrangedView(self.blueBox) { (component) in
                 component.activate([
-                    view.heightAnchor.constraint(equalToConstant: 100)
+                    component.view.heightAnchor.constraint(equalToConstant: 100)
                 ])
             }
         }
@@ -191,28 +191,3 @@ pod "DeclarativeLayout"
 
 DeclarativeLayout is available under the MIT license. See the LICENSE file for more info.
 
-## Tips
-
-* This framework makes heavy use of closures and Xcode doesn't always autocomplete using trailing closure syntax. I would suggest making snippets in Xcode to make your development more fluid. Here are the different statements you may want to make snippets for:
-
-```swift
-viewLayout.updateLayoutTo { (component, view) in
-    <#code#>
-}
-
-component.addView(<#view#>) { (component, view, superview) in
-    <#code#>
-}
-
-component.addStackView(<#view#>) { (component, view, superview) in
-    <#code#>
-}
-
-component.addArrangedView(<#view#>) { (component, view, superview) in
-    <#code#>
-}
-
-component.activate([
-    <#constraint#>,
-])
-```


### PR DESCRIPTION
This removes passing the view and superview in the component closure. The reason for this is making it easier to use the framework by requiring less typing and not requiring snippets, etc which I was using.

This also shows how you might add some useful extensions to make referencing the view and superview easier, since it now isn't passed in the component closure.